### PR TITLE
PYTHON-1324: Add a few more wheel builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,14 @@ jobs:
     env:
     - MB_PYTHON_VERSION=3.9
     - PLAT=i686
+  - arch: arm64
+    os: linux
+    services: docker
+    env:
+    - MB_PYTHON_VERSION=3.9
+    - MB_ML_VER=2014
+    - PLAT=aarch64
+    - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
   - os: linux
     env:
     - MB_PYTHON_VERSION=3.10
@@ -59,4 +67,29 @@ jobs:
     - MB_PYTHON_VERSION=3.10
     - MB_ML_VER=2010
     - PLAT=i686
+  - arch: arm64
+    os: linux
+    services: docker
+    env:
+    - MB_PYTHON_VERSION=3.10
+    - MB_ML_VER=2014
+    - PLAT=aarch64
+    - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+  - os: linux
+    env:
+    - MB_PYTHON_VERSION=3.11
+    - MB_ML_VER=2014
+  - os: linux
+    env:
+    - MB_PYTHON_VERSION=3.11
+    - MB_ML_VER=2014
+    - PLAT=i686
+  - arch: arm64
+    os: linux
+    services: docker
+    env:
+    - MB_PYTHON_VERSION=3.11
+    - MB_ML_VER=2014
+    - PLAT=aarch64
+    - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
 script: bash build_wheel.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,6 @@ jobs:
     - MB_PYTHON_VERSION=3.10
     - MB_ML_VER=2010
     - PLAT=i686
-    - DOCKER_TEST_IMAGE=multibuild/focal_x86_64
   - arch: arm64
     os: linux
     services: docker
@@ -87,7 +86,6 @@ jobs:
     - MB_PYTHON_VERSION=3.11
     - MB_ML_VER=2014
     - PLAT=i686
-    - DOCKER_TEST_IMAGE=multibuild/focal_x86_64
   - arch: arm64
     os: linux
     services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,13 +62,13 @@ jobs:
     env:
     - MB_PYTHON_VERSION=3.10
     - MB_ML_VER=2010
-    - DOCKER_TEST_IMAGE=multibuild/focal_arm64v8
+    - DOCKER_TEST_IMAGE=multibuild/focal_x86_64
   - os: linux
     env:
     - MB_PYTHON_VERSION=3.10
     - MB_ML_VER=2010
     - PLAT=i686
-    - DOCKER_TEST_IMAGE=multibuild/focal_arm64v8
+    - DOCKER_TEST_IMAGE=multibuild/focal_x86_64
   - arch: arm64
     os: linux
     services: docker
@@ -81,13 +81,13 @@ jobs:
     env:
     - MB_PYTHON_VERSION=3.11
     - MB_ML_VER=2014
-    - DOCKER_TEST_IMAGE=multibuild/focal_arm64v8
+    - DOCKER_TEST_IMAGE=multibuild/focal_x86_64
   - os: linux
     env:
     - MB_PYTHON_VERSION=3.11
     - MB_ML_VER=2014
     - PLAT=i686
-    - DOCKER_TEST_IMAGE=multibuild/focal_arm64v8
+    - DOCKER_TEST_IMAGE=multibuild/focal_x86_64
   - arch: arm64
     os: linux
     services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,4 +94,29 @@ jobs:
     - MB_ML_VER=2014
     - PLAT=aarch64
     - DOCKER_TEST_IMAGE=multibuild/focal_arm64v8
+  - os: osx
+    osx_image: xcode11
+    language: generic
+    env:
+    - MB_PYTHON_VERSION=3.7
+  - os: osx
+    osx_image: xcode11
+    language: generic
+    env:
+    - MB_PYTHON_VERSION=3.8
+  - os: osx
+    osx_image: xcode11
+    language: generic
+    env:
+    - MB_PYTHON_VERSION=3.9
+  - os: osx
+    osx_image: xcode11
+    language: generic
+    env:
+    - MB_PYTHON_VERSION=3.10
+  - os: osx
+    osx_image: xcode11
+    language: generic
+    env:
+    - MB_PYTHON_VERSION=3.11
 script: bash build_wheel.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,13 @@ jobs:
     env:
     - MB_PYTHON_VERSION=3.10
     - MB_ML_VER=2010
+    - DOCKER_TEST_IMAGE=multibuild/focal_arm64v8
   - os: linux
     env:
     - MB_PYTHON_VERSION=3.10
     - MB_ML_VER=2010
     - PLAT=i686
+    - DOCKER_TEST_IMAGE=multibuild/focal_arm64v8
   - arch: arm64
     os: linux
     services: docker
@@ -74,16 +76,18 @@ jobs:
     - MB_PYTHON_VERSION=3.10
     - MB_ML_VER=2014
     - PLAT=aarch64
-    - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+    - DOCKER_TEST_IMAGE=multibuild/focal_arm64v8
   - os: linux
     env:
     - MB_PYTHON_VERSION=3.11
     - MB_ML_VER=2014
+    - DOCKER_TEST_IMAGE=multibuild/focal_arm64v8
   - os: linux
     env:
     - MB_PYTHON_VERSION=3.11
     - MB_ML_VER=2014
     - PLAT=i686
+    - DOCKER_TEST_IMAGE=multibuild/focal_arm64v8
   - arch: arm64
     os: linux
     services: docker
@@ -91,5 +95,5 @@ jobs:
     - MB_PYTHON_VERSION=3.11
     - MB_ML_VER=2014
     - PLAT=aarch64
-    - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+    - DOCKER_TEST_IMAGE=multibuild/focal_arm64v8
 script: bash build_wheel.sh


### PR DESCRIPTION
* Added Python 3.11 builds for x86_64 and ARM64 (PYTHON-1324)
* Filled in ARM builds for 3.9 and 3.10.  These weren't added as part of the original support for ARM builds (PYTHON-1278)

Something of an experiment to see how readily we can build the new platforms.  If this works on a first attempt I'm fine including it with the 3.26.0 release but if there's really any substantial failure at all we'll back this out and fix it later.  It's more important to get 3.26.0 out the door with what we have now than to delay it with concerns about wheel builds that can be resolved immediately after the package is released.