### PR TITLE
use cibuildwheel to create all wheels for Linux, MacOS and Windows

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,6 +1,6 @@
 name: Build wheels
 
-on: [push, pull_request, workflow_dispatch]
+on: [workflow_dispatch]
 
 jobs:
   build_wheels:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,34 @@
+name: Build wheels
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-11]
+    env:
+      CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-*
+      CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+      CIBW_ARCHS_LINUX: x86_64 i686 aarch64
+      CIBW_TEST_REQUIRES: nose mock pure-sasl eventlet
+      CIBW_TEST_COMMAND: echo "wheel is installed"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/arm64
+
+      - name: Build wheels
+        run: cd python-driver && pipx run cibuildwheel==2.12.1
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: python-driver/wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -11,6 +11,7 @@ jobs:
         os: [ubuntu-20.04, windows-2019, macos-11]
     env:
       CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-*
+      CIBW_SKIP: *musllinux*
       CIBW_ARCHS_MACOS: x86_64 arm64 universal2
       CIBW_ARCHS_LINUX: x86_64 i686 aarch64
       CIBW_TEST_REQUIRES: nose mock pure-sasl eventlet

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-20.04, windows-2019, macos-11]
     env:
       CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-*
-      CIBW_SKIP: *musllinux*
+      CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS_MACOS: x86_64 arm64 universal2
       CIBW_ARCHS_LINUX: x86_64 i686 aarch64
       CIBW_TEST_REQUIRES: nose mock pure-sasl eventlet


### PR DESCRIPTION
Note I'm not removing travis config and multibuild submodule for now. Once we've proved that github action and cibuildwheel can handle all python driver wheel releases, we can remove travis and multibuild in another PR.