### PR TITLE
PYTHON-1387 Strip symbols from compiled shared objects

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -13,6 +13,7 @@ jobs:
       CIBW_TEST_REQUIRES: pynose mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
       CIBW_BEFORE_ALL: yum install -y libev libev-devel
+      CIBW_ENVIRONMENT: CFLAGS='--strip-all'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -13,7 +13,7 @@ jobs:
       CIBW_TEST_REQUIRES: pynose mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
       CIBW_BEFORE_ALL: yum install -y libev libev-devel
-      CIBW_ENVIRONMENT: CFLAGS='--strip-all'
+      CIBW_ENVIRONMENT: CFLAGS='-s'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
In testing Python driver 3.29.1 wheel for Python 3.8/aarch64 is now ~3.5M rather than ~20M for what's currently on Pypi.  Testing with a few local test apps showed no regression.