### PR TITLE
PYTHON-1396 Linux wheel builds appear to be failing due to retirement of CentOS 7

### DIFF
--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -28,4 +28,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-linux
-          path: python-driver/wheelhouse/*.whl
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -27,5 +27,5 @@ jobs:
           package-dir: ./python-driver
       - uses: actions/upload-artifact@v4
         with:
-	  name: cibw-wheels-linux
+          name: cibw-wheels-linux
           path: python-driver/wheelhouse/*.whl

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -7,9 +7,9 @@ jobs:
     name: Build wheels on ubuntu-20.04
     runs-on: ubuntu-20.04
     env:
-      CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
+      CIBW_BUILD: cp38-* cp312-*
       CIBW_SKIP: "*musllinux*"
-      CIBW_ARCHS_LINUX: x86_64 aarch64
+      CIBW_ARCHS_LINUX: x86_64
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
       CIBW_BEFORE_ALL: yum install -y libev libev-devel

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -7,9 +7,9 @@ jobs:
     name: Build wheels on ubuntu-20.04
     runs-on: ubuntu-20.04
     env:
-      CIBW_BUILD: cp38-* cp312-*
+      CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
       CIBW_SKIP: "*musllinux*"
-      CIBW_ARCHS_LINUX: x86_64
+      CIBW_ARCHS_LINUX: x86_64 aarch64
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
       CIBW_BEFORE_ALL: yum install -y libev libev-devel

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -10,20 +10,22 @@ jobs:
       CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
       CIBW_SKIP: "*musllinux*"
       CIBW_ARCHS_LINUX: x86_64 aarch64
-      CIBW_TEST_REQUIRES: pynose mock pure-sasl eventlet
+      CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
       CIBW_BEFORE_ALL: yum install -y libev libev-devel
       CIBW_ENVIRONMENT: CFLAGS='-s'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
           platforms: linux/arm64
-      - name: Build wheels
-        run: cd python-driver && pipx run cibuildwheel==2.16.2
-      - uses: actions/upload-artifact@v3
+      - uses: pypa/cibuildwheel@v2.19.2
         with:
+          package-dir: ./python-driver
+      - uses: actions/upload-artifact@v4
+        with:
+	  name: cibw-wheels-linux
           path: python-driver/wheelhouse/*.whl

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         # macos-13 == Intel, macos-14 == ARM
         os: [macos-13, macos-14]
-	min_version: [10.9, 11.0]
+        min_version: [10.9, 11.0]
 	exclude:
           # Always try for the maximal min version for x86_64 builds
           - os: macos-13

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -16,10 +16,10 @@ jobs:
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
       CIBW_BEFORE_ALL: >
-        curl -O http://dist.schmorp.de/libev/libev-4.33.tar.gz
-        gzip -dc libev-4.33.tar.gz | tar xf -
-        cd libev-4.33
-        ./configure
+        curl -O http://dist.schmorp.de/libev/libev-4.33.tar.gz &&
+        gzip -dc libev-4.33.tar.gz | tar xf - &&
+        cd libev-4.33 &&
+        ./configure &&
         make install
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -15,7 +15,13 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
-      CIBW_BEFORE_ALL: brew install --build-from-source libev
+      CIBW_BEFORE_ALL: >
+        curl -O http://dist.schmorp.de/libev/libev-4.33.tar.gz
+        gzip -dc libev-4.33.tar.gz | tar xf -
+        cd libev-4.33
+        ./configure
+        make install
+brew install --build-from-source libev
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -11,7 +11,7 @@ jobs:
         # macos-13 == Intel, macos-14 == ARM
         os: [macos-13, macos-14]
         min_version: [10.9, 11.0]
-	exclude:
+        exclude:
           # Always try for the maximal min version for x86_64 builds
           - os: macos-13
             min_version: 11.0

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -20,7 +20,7 @@ jobs:
         gzip -dc libev-4.33.tar.gz | tar xf - &&
         cd libev-4.33 &&
         ./configure &&
-        make install
+        sudo make install
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -10,8 +10,16 @@ jobs:
       matrix:
         # macos-13 == Intel, macos-14 == ARM
         os: [macos-13, macos-14]
+	min_version: [10.9, 11.0]
+	exclude:
+          # Always try for the maximal min version for x86_64 builds
+          - os: macos-13
+            min_version: 11.0
+          # ARM builds require an OSX version of at least 11.0
+          - os: macos-14
+            min_version: 10.9
     env:
-      CIBW_ENVIRONMENT: CFLAGS="-mmacosx-version-min=10.9"
+      CIBW_ENVIRONMENT: CFLAGS="-mmacosx-version-min=${{ matrix.min_version }}"
       CIBW_BUILD: cp38-* cp312-*
       CIBW_SKIP: "*musllinux*"
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -15,7 +15,7 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
-      CIBW_BEFORE_ALL: brew install libev@10.9
+      CIBW_BEFORE_ALL: brew install --build-from-source libev
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -11,13 +11,13 @@ jobs:
         # macos-13 == Intel, macos-14 == ARM
         os: [macos-13, macos-14]
     env:
-      CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=10.9
+      CIBW_ENVIRONMENT: CFLAGS="-mmacosx-version-min=10.9"
       CIBW_BUILD: cp38-* cp312-*
       CIBW_SKIP: "*musllinux*"
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
       CIBW_BEFORE_ALL: >
-        CFLAGS="-mmacosx-version-min=10.9" curl -O http://dist.schmorp.de/libev/libev-4.33.tar.gz &&
+        curl -O http://dist.schmorp.de/libev/libev-4.33.tar.gz &&
         gzip -dc libev-4.33.tar.gz | tar xf - &&
         cd libev-4.33 &&
         ./configure &&

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -15,6 +15,12 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
+      CIBW_BEFORE_ALL: >
+        curl -O http://dist.schmorp.de/libev/libev-4.33.tar.gz &&
+        gzip -dc libev-4.33.tar.gz | tar xf - &&
+        cd libev-4.33 &&
+        ./configure &&
+        sudo make install
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -20,7 +20,7 @@ jobs:
             min_version: 10.9
     env:
       CIBW_ENVIRONMENT: CFLAGS="-mmacosx-version-min=${{ matrix.min_version }}"
-      CIBW_BUILD: cp38-* cp312-*
+      CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
       CIBW_SKIP: "*musllinux*"
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -13,17 +13,17 @@ jobs:
     env:
       CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
       CIBW_SKIP: "*musllinux*"
-      CIBW_TEST_REQUIRES: pynose mock pure-sasl eventlet
+      CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
       CIBW_BEFORE_ALL: brew install libev
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: pypa/cibuildwheel@v2.17.0
+      - uses: pypa/cibuildwheel@v2.19.2
         with:
           package-dir: ./python-driver
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: cibw-wheels-mac-${{ matrix.os }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -15,7 +15,7 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
-      CIBW_BEFORE_ALL: brew install libev
+      CIBW_BEFORE_ALL: brew install libev@10.9
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -11,12 +11,13 @@ jobs:
         # macos-13 == Intel, macos-14 == ARM
         os: [macos-13, macos-14]
     env:
+      CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=10.9
       CIBW_BUILD: cp38-* cp312-*
       CIBW_SKIP: "*musllinux*"
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
       CIBW_BEFORE_ALL: >
-        MACOSX_DEPLOYMENT_TARGET=10.9 curl -O http://dist.schmorp.de/libev/libev-4.33.tar.gz &&
+        curl -O http://dist.schmorp.de/libev/libev-4.33.tar.gz &&
         gzip -dc libev-4.33.tar.gz | tar xf - &&
         cd libev-4.33 &&
         ./configure &&

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -21,7 +21,6 @@ jobs:
         cd libev-4.33
         ./configure
         make install
-brew install --build-from-source libev
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -17,7 +17,7 @@ jobs:
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
       CIBW_BEFORE_ALL: >
-        curl -O http://dist.schmorp.de/libev/libev-4.33.tar.gz &&
+        CFLAGS="-mmacosx-version-min=10.9" curl -O http://dist.schmorp.de/libev/libev-4.33.tar.gz &&
         gzip -dc libev-4.33.tar.gz | tar xf - &&
         cd libev-4.33 &&
         ./configure &&

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -15,12 +15,6 @@ jobs:
       CIBW_SKIP: "*musllinux*"
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
-      CIBW_BEFORE_ALL: >
-        curl -O http://dist.schmorp.de/libev/libev-4.33.tar.gz &&
-        gzip -dc libev-4.33.tar.gz | tar xf - &&
-        cd libev-4.33 &&
-        ./configure &&
-        sudo make install
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -16,7 +16,7 @@ jobs:
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"
       CIBW_BEFORE_ALL: >
-        curl -O http://dist.schmorp.de/libev/libev-4.33.tar.gz &&
+        MACOSX_DEPLOYMENT_TARGET=10.9 curl -O http://dist.schmorp.de/libev/libev-4.33.tar.gz &&
         gzip -dc libev-4.33.tar.gz | tar xf - &&
         cd libev-4.33 &&
         ./configure &&

--- a/.github/workflows/build_wheels_mac.yml
+++ b/.github/workflows/build_wheels_mac.yml
@@ -11,7 +11,7 @@ jobs:
         # macos-13 == Intel, macos-14 == ARM
         os: [macos-13, macos-14]
     env:
-      CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
+      CIBW_BUILD: cp38-* cp312-*
       CIBW_SKIP: "*musllinux*"
       CIBW_TEST_REQUIRES: pytest mock pure-sasl eventlet
       CIBW_TEST_COMMAND: echo "wheel is installed"


### PR DESCRIPTION
Noted while doing some testing for initial work on PYTHON-1386.

Primary goal of this fix is to get Linux builds going again after CentOS 7 has gone EOL but a secondary goal would be to try to get the various build files to agree on a common configuration.